### PR TITLE
aquestalk/Cargo.toml関係のリファクタ

### DIFF
--- a/aquestalk/Cargo.toml
+++ b/aquestalk/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dependencies]
 libaquestalk-sys = { version = "0.1.4", optional = true }
+libaquestalk2-sys = { version = "0.1.0", optional = true }
 
 [features]
 aquestalk1 = ["libaquestalk-sys"]

--- a/aquestalk/Cargo.toml
+++ b/aquestalk/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libaquestalk-sys = { version = "0.1.4", optional = true }
-libaquestalk2-sys = { version = "0.1.0", optional = true }
+libaquestalk-sys = { version = "0.1.4", optional = true, path = "../libaquestalk-sys" }
+libaquestalk2-sys = { version = "0.1.0", optional = true, path = "../libaquestalk2-sys" }
 
 [features]
 aquestalk1 = ["libaquestalk-sys"]


### PR DESCRIPTION
- libaquestalk2-sysがdepsに入っておらず、cargo metadataが実行できない
- depsのどれかがpublishされてないと動かない
上記2点を修正